### PR TITLE
Update to support BSD man(1) as well as GNU man(1)

### DIFF
--- a/shelldoc.el
+++ b/shelldoc.el
@@ -152,17 +152,14 @@ If you need to read default, set to nil."
     ;; 1. Executable programs or shell commands
     ;; 8. System administration commands (usually only for root)
     (setq args (append
-                (list (format "--sections=%s"
-                              (or shelldoc--man-section
-                                  "1,8")))
+                (list "-S" (or shelldoc--man-section "1:8")))
                 args))
     (setq args (append args (list name)))
     (shelldoc--call-man-to-string args)))
 
 (defun shelldoc--manpage-exists-p (name)
   (let* ((args (list
-                (format "--sections=%s"
-                        (or shelldoc--man-section "1,8"))
+                (list "-S" (or shelldoc--man-section "1:8")))
                 "--where" name))
          (out (shelldoc--call-man-to-string args)))
     (and out (s-trim out))))


### PR DESCRIPTION
BSD man(1) doesn't support the same `--sections` format an GNU does.
GNU man(1) does support the BSD version of the argument, though,
so it is compatible to use `-S 1:8` with both.

This switches to the BSD version, `-S`, and colon-separated section
numbers.  Tested on macOS and GNU/Linux, where it works correctly.